### PR TITLE
Fixed bug in greedy set cover heuristic

### DIFF
--- a/graphilp/covering/heuristics/setcover_greedy.py
+++ b/graphilp/covering/heuristics/setcover_greedy.py
@@ -32,7 +32,7 @@ def get_heuristic(S, k=None):
     result = []
 
     # while there are elements to be covered and sets to choose from
-    while (sum(not_covered) > 0) and (len(result) < k):
+    while any(not_covered) and (len(result) < k) and len(sets) > 0:
 
         # pick most efficient set and add it to the solution
         chosen_set = min([(S.S[set_names[_set]]['weight'] / set_sizes[_set], _set) for _set in sets])[1]
@@ -43,5 +43,17 @@ def get_heuristic(S, k=None):
 
         # remove chosen set
         sets.remove(chosen_set)
+
+        # update set sizes
+        covered = list()
+        for _set in sets:
+            set_sizes[_set] = sum(not_covered & S.M[:, _set])
+            # if all elements of a set are covered
+            if set_sizes[_set] == 0:
+                covered.append(_set)
+
+        # remove covered sets
+        for _set in covered:
+            sets.remove(_set)
 
     return [set_names[s] for s in result]

--- a/graphilp/tests/covering/test_heuristic_k_cover.py
+++ b/graphilp/tests/covering/test_heuristic_k_cover.py
@@ -1,6 +1,8 @@
 from numpy import array
 from graphilp.imports import ilpsetsystem as ilpss
 from graphilp.covering.heuristics import setcover_greedy
+from graphilp.tests.covering.test_heuristic_set_cover import _is_set_covered
+
 
 def test_heuristic_k_cover():
     S = ilpss.ILPSetSystem()
@@ -15,3 +17,4 @@ def test_heuristic_k_cover():
     cover = setcover_greedy.get_heuristic(S, k)
 
     assert(len(cover) <= k)
+    assert _is_set_covered(S, cover)

--- a/graphilp/tests/covering/test_heuristic_set_cover.py
+++ b/graphilp/tests/covering/test_heuristic_set_cover.py
@@ -1,21 +1,26 @@
 # +
 from numpy import array, zeros
-from graphilp.imports import ilpsetsystem as ilpss
+
 from graphilp.covering.heuristics import setcover_greedy
+from graphilp.imports import ilpsetsystem as ilpss
+
 
 def test_heuristic_set_cover():
     S = ilpss.ILPSetSystem()
-
-    S.set_system({1: {'weight': 1}, 2: {'weight': 1}, 3: {'weight': 1}, 4: {'weight': 1}, 5: {'weight': 1}})
-    S.set_universe({1: {'weight': 1}, 2: {'weight': 1}, 3: {'weight': 1}, 4: {'weight': 1}, 5: {'weight': 1}, 6: {'weight': 1}})
-    M = array([[1,1,1,0,0,0], [0,0,0,1,1,1], [1,1,0,0,0,0], [0,0,1,1,0,0], [0,0,0,0,1,1]])
+    S.set_universe({0: {'weight': 1}, 1: {'weight': 1}, 2: {'weight': 1}, 3: {'weight': 1}})
+    S.set_system({0: {'weight': 1}, 1: {'weight': 1}, 2: {'weight': 1}})
+    M = array([[0, 0, 0, 1], [1, 1, 1, 0], [0, 1, 1, 0]])
     S.set_inc_matrix(M.transpose())
 
     cover = setcover_greedy.get_heuristic(S)
-    set_vector = zeros(len(S.S))
-    for index, setname in enumerate(S.S):
-        if setname in cover:
-            set_vector[index] = 1
-    covered = sum(sum((S.M*set_vector).transpose())) >= len(S.U)
 
-    assert(covered == True)
+    assert _is_set_covered(S, cover)
+    assert cover == [1, 0], "Expected: [1, 0]"
+
+
+def _is_set_covered(S, cover):
+    set_vector = zeros(len(S.S))
+    for index, set_name in enumerate(S.S):
+        if set_name in cover:
+            set_vector[index] = 1
+    return sum(sum((S.M * set_vector).transpose())) >= len(S.U)


### PR DESCRIPTION
## Why?

The greedy set cover heuristic should select the set that covers the most **uncovered** elements of the universe in each step. 
The current implementation does that correctly in the first step, but the `set_sizes` (= number of uncovered nodes per set) are never updated. So the method always picks the set that contains the most elements regardless whether they are already covered or not.

## Changes
- removed sets as soon as all their elements are covered
- designed a different test case that catches the bug
- tested both if the whole set is covered and if the selected subsets are equal to the expected sets